### PR TITLE
Refactor to utilize tracked state

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 with open('README.md') as f:
     long_description = f.read()
 
-VERSION="0.0.8"
+VERSION="0.0.9"
 
 setup(
     name='plexwebsocket',


### PR DESCRIPTION
Instead of storing `asyncio.Task.current_task()` and calling `cancel()` on shutdown, track the state of the connection and cleanly exit from inside the websocket loop.